### PR TITLE
Support casts from private inner types

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -45,15 +45,14 @@ fn expand(input: DeriveInput) -> Result<TokenStream2> {
     };
 
     Ok(quote! {
-        impl #impl_generics ::ref_cast::RefCast for #name #ty_generics #where_clause {
-            type From = #from;
+        impl #impl_generics ::ref_cast::RefCast<#from> for #name #ty_generics #where_clause {
 
             #[inline]
-            fn ref_cast(_from: &Self::From) -> &Self {
-                // TODO: assert that `Self::From` and `Self` have the same size
+            fn ref_cast(_from: &#from) -> &Self {
+                // TODO: assert that `#from` and `Self` have the same size
                 // and alignment.
                 //
-                // Cannot do this because `Self::From` may be a generic type
+                // Cannot do this because `#from` may be a generic type
                 // parameter of `Self` where `transmute` is not allowed:
                 //
                 //     #[allow(unused)]
@@ -63,23 +62,23 @@ fn expand(input: DeriveInput) -> Result<TokenStream2> {
                 //                 _core::mem::uninitialized()));
                 //     }
                 //
-                // Cannot do this because `Self::From` may not be sized:
+                // Cannot do this because `#from` may not be sized:
                 //
-                //     debug_assert_eq!(_core::mem::size_of::<Self::From>(),
+                //     debug_assert_eq!(_core::mem::size_of::<#from>(),
                 //                      _core::mem::size_of::<Self>());
-                //     debug_assert_eq!(_core::mem::align_of::<Self::From>(),
+                //     debug_assert_eq!(_core::mem::align_of::<#from>(),
                 //                      _core::mem::align_of::<Self>());
 
                 #assert_trivial_fields
                 unsafe {
-                    &*(_from as *const Self::From as *const Self)
+                    &*(_from as *const #from as *const Self)
                 }
             }
 
             #[inline]
-            fn ref_cast_mut(_from: &mut Self::From) -> &mut Self {
+            fn ref_cast_mut(_from: &mut #from) -> &mut Self {
                 unsafe {
-                    &mut *(_from as *mut Self::From as *mut Self)
+                    &mut *(_from as *mut #from as *mut Self)
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,10 +155,9 @@ pub use ref_cast_impl::RefCast;
 /// ```
 ///
 /// See the crate-level documentation for usage examples!
-pub trait RefCast {
-    type From: ?Sized;
-    fn ref_cast(from: &Self::From) -> &Self;
-    fn ref_cast_mut(from: &mut Self::From) -> &mut Self;
+pub trait RefCast<From: ?Sized> {
+    fn ref_cast(from: &From) -> &Self;
+    fn ref_cast_mut(from: &mut From) -> &mut Self;
 }
 
 // Not public API.

--- a/tests/test_private.rs
+++ b/tests/test_private.rs
@@ -1,0 +1,13 @@
+use ref_cast::RefCast;
+
+struct PrivateType(usize);
+
+
+#[derive(RefCast)]
+#[repr(transparent)]
+pub struct Wrapper(PrivateType);
+
+#[test]
+fn test_private() {
+    Wrapper::ref_cast(&PrivateType(3));
+}


### PR DESCRIPTION
Fixes #3, but changes `From` from an associated type to a generic type parameter, which is a breaking change.

This also means that a type can have multiple RefCast implementations now. We won't derive more than one, so it seems a bit academic, but there's actually a slight benefit to this: if someone has Outer(Middle(Inner)), Outer can impl RefCast for both Middle and Inner now\*.

Admittedly, I'm not really sure why anybody would want this in practice, but it's not *that* hard to imagine -- I've definitely had multiple layers of repr(transparent) types when doing simd code (although, that has enough `unsafe` that I wouldn't bother reaching for this crate).

That said, you might have different opinions on this than I do.

---

\* One of the impls would have to be manual, but if they derive (`RefCast<Middle>` for) `Outer` and (`RefCast<Inner>` for) `Middle`, then they could implement `RefCast<Inner> for Outer` without `unsafe`, as something like `Outer::ref_cast(Middle::ref_cast(inner))`
