### PR TITLE
Revert "Work around rustc fn ptr parsing regression"

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -160,9 +160,7 @@ fn trivial_fields(fields: &Fields) -> Result<Vec<&Type>> {
     Ok(trivial)
 }
 
-// FIXME: https://github.com/rust-lang/rust/issues/78507
-type Workaround = fn(&Field) -> Result<bool>;
-fn decide_trivial(fields: &Fields) -> Result<Workaround> {
+fn decide_trivial(fields: &Fields) -> Result<fn(&Field) -> Result<bool>> {
     for field in fields {
         if is_explicit_trivial(field)? {
             return Ok(is_explicit_trivial);


### PR DESCRIPTION
Fixed in nightly-2020-10-31. Closes #14.