### PR TITLE
#23 - Derivative attribute `crate`

### DIFF
--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -73,16 +73,14 @@ fn parse_meta_items(attr: &syn::Attribute) -> crate::Result<Vec<syn::NestedMeta>
 
     match attr.parse_meta()? {
         List(meta) => Ok(meta.nested.into_iter().collect()),
-        other => {
-            return Err(Error::new_spanned(
-                other.into_token_stream(),
-                "expected #[ref_cast(...)]",
-            ))
-        }
+        other => Err(Error::new_spanned(
+            other.into_token_stream(),
+            "expected #[ref_cast(...)]",
+        )),
     }
 }
 
-fn get_lit_str<'a>(attr_name: Symbol, lit: &'a syn::Lit) -> crate::Result<&'a syn::LitStr> {
+fn get_lit_str(attr_name: Symbol, lit: &syn::Lit) -> crate::Result<&syn::LitStr> {
     use syn::Lit;
     match lit {
         Lit::Str(lit) => Ok(lit),

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -11,7 +11,7 @@ use {
     },
 };
 
-use crate::symbols::*;
+use crate::symbols::{Symbol, CRATE, REF_CAST};
 
 /// Represents container attribute information.
 pub struct Container {
@@ -32,7 +32,7 @@ impl Container {
             match &meta_item {
                 // Parse `#[ref_cast(crate = "foo")]`
                 NestedMeta::Meta(NameValue(m)) if m.path == CRATE => {
-                    crate_ref_cast_path = Some(parse_lit_into_path(CRATE, &m.lit)?)
+                    crate_ref_cast_path = Some(parse_lit_into_path(CRATE, &m.lit)?);
                 }
                 NestedMeta::Meta(meta_item) => {
                     let path = meta_item
@@ -61,10 +61,10 @@ impl Container {
     }
 }
 
-/// Parses element of ref_cast attributes list for example `crate = "ref_cast_alias"` in
+/// Parses element of `ref_cast` attributes list for example `crate = "ref_cast_alias"` in
 /// `#[ref_cast(crate = "ref_cast_alias")]`
 ///
-/// See [syn::NestedMeta](/syn/enum.NestedMeta.html) for more info.
+/// See [`syn::NestedMeta`](/syn/enum.NestedMeta.html) for more info.
 fn parse_meta_items(attr: &syn::Attribute) -> crate::Result<Vec<syn::NestedMeta>> {
     use syn::Meta::List;
     if attr.path != REF_CAST {

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -1,0 +1,125 @@
+//! This module handles parsing of `#[ref_cast(...)]` attributes. The entrypoints
+//! is `attr::Container::from_ast`. It returns an instance of the corresponding
+//! struct.
+
+use {
+    proc_macro2::{Group, Span, TokenStream, TokenTree},
+    quote::ToTokens,
+    syn::{
+        parse::{self, Parse},
+        Error,
+    },
+};
+
+use crate::symbols::*;
+
+/// Represents container attribute information.
+pub struct Container {
+    pub crate_ref_cast_path: syn::Path,
+}
+
+impl Container {
+    /// Extract out the `#[ref_cast(...)]` attributes from an item.
+    pub fn from_ast(item: &syn::DeriveInput) -> crate::Result<Self> {
+        let mut crate_ref_cast_path = None;
+        for meta_item in item
+            .attrs
+            .iter()
+            .flat_map(|attr| parse_meta_items(attr))
+            .flatten()
+        {
+            use syn::{Meta::NameValue, NestedMeta};
+            match &meta_item {
+                // Parse `#[ref_cast(crate = "foo")]`
+                NestedMeta::Meta(NameValue(m)) if m.path == CRATE => {
+                    crate_ref_cast_path = Some(parse_lit_into_path(CRATE, &m.lit)?)
+                }
+                NestedMeta::Meta(meta_item) => {
+                    let path = meta_item
+                        .path()
+                        .into_token_stream()
+                        .to_string()
+                        .replace(' ', "");
+                    return Err(Error::new_spanned(
+                        meta_item.path(),
+                        format!("unknown ref_cast container attribute `{}`", path),
+                    ));
+                }
+                NestedMeta::Lit(lit) => {
+                    return Err(Error::new_spanned(
+                        lit,
+                        "unexpected literal in ref_cast container attribute",
+                    ));
+                }
+            }
+        }
+
+        Ok(Self {
+            crate_ref_cast_path: crate_ref_cast_path
+                .unwrap_or_else(|| syn::parse_str(&format!("::{}", REF_CAST)).unwrap()),
+        })
+    }
+}
+
+/// Parses element of ref_cast attributes list for example `crate = "ref_cast_alias"` in
+/// `#[ref_cast(crate = "ref_cast_alias")]`
+///
+/// See [syn::NestedMeta](/syn/enum.NestedMeta.html) for more info.
+fn parse_meta_items(attr: &syn::Attribute) -> crate::Result<Vec<syn::NestedMeta>> {
+    use syn::Meta::List;
+    if attr.path != REF_CAST {
+        return Ok(Vec::new());
+    }
+
+    match attr.parse_meta()? {
+        List(meta) => Ok(meta.nested.into_iter().collect()),
+        other => {
+            return Err(Error::new_spanned(
+                other.into_token_stream(),
+                "expected #[ref_cast(...)]",
+            ))
+        }
+    }
+}
+
+fn get_lit_str<'a>(attr_name: Symbol, lit: &'a syn::Lit) -> crate::Result<&'a syn::LitStr> {
+    use syn::Lit;
+    match lit {
+        Lit::Str(lit) => Ok(lit),
+        _ => Err(Error::new_spanned(
+            lit,
+            format!(
+                "expected ref_cast {0} attribute to be a string: `{0} = \"...\"`",
+                attr_name
+            ),
+        )),
+    }
+}
+
+fn parse_lit_into_path(attr_name: Symbol, lit: &syn::Lit) -> crate::Result<syn::Path> {
+    let string = get_lit_str(attr_name, lit)?;
+    parse_lit_str(string)
+        .map_err(|_| Error::new_spanned(lit, format!("failed to parse path: {:?}", string.value())))
+}
+
+/// Parses a string litteral as rust code
+fn parse_lit_str<T>(s: &syn::LitStr) -> parse::Result<T>
+where
+    T: Parse,
+{
+    let stream = syn::parse_str(&s.value())?;
+    syn::parse2(respan_token_stream(stream, s.span()))
+}
+
+fn respan_token_stream(stream: TokenStream, span: Span) -> TokenStream {
+    stream
+        .into_iter()
+        .map(|mut token| {
+            if let TokenTree::Group(g) = &mut token {
+                *g = Group::new(g.delimiter(), respan_token_stream(g.stream(), span));
+            }
+            token.set_span(span);
+            token
+        })
+        .collect()
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -25,7 +25,7 @@ mod symbols;
 /// macro_rules! my_macro {
 ///     () => {
 ///         #[derive($crate::ref_cast::RefCast)]
-///         #[ref_cast(crate = "$crate::ref_cast")]
+///         #[ref_cast(crate = "my_crate::ref_cast")]
 ///         #[repr(transparent)]
 ///         struct MyStruct {
 ///             my_field: String,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -17,8 +17,8 @@ mod symbols;
 /// # Container attributes
 /// - `#[ref_cast(crate = "...")]`
 ///
-///  Specify a path to the `ref_cast` crate instance to use when referring to ref_cast APIs from generated code. This is
-/// normally only applicable when invoking re-exported ref_cast derives from a public macro in a different crate.
+///  Specify a path to the `ref_cast` crate instance to use when referring to `ref_cast` APIs from generated code. This
+/// is normally only applicable when invoking re-exported `ref_cast` derives from a public macro in a different crate.
 /// ```
 /// pub use ref_cast;
 /// #[macro_export]

--- a/derive/src/symbols.rs
+++ b/derive/src/symbols.rs
@@ -1,0 +1,46 @@
+use {
+    std::fmt::{self, Display},
+    syn::{Ident, Path},
+};
+
+#[derive(Copy, Clone)]
+pub struct Symbol(&'static str);
+
+pub const REF_CAST: Symbol = Symbol("ref_cast");
+pub const CRATE: Symbol = Symbol("crate");
+
+impl Symbol {
+    pub fn value(&self) -> &'static str {
+        self.0
+    }
+}
+
+impl PartialEq<Symbol> for Ident {
+    fn eq(&self, word: &Symbol) -> bool {
+        self == word.0
+    }
+}
+
+impl<'a> PartialEq<Symbol> for &'a Ident {
+    fn eq(&self, word: &Symbol) -> bool {
+        *self == word.0
+    }
+}
+
+impl PartialEq<Symbol> for Path {
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
+}
+
+impl<'a> PartialEq<Symbol> for &'a Path {
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
+}
+
+impl Display for Symbol {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}


### PR DESCRIPTION
Resolves #23

**What it does:**
- Adds module `attr` to parse ref_cast attributes
- Adds container attribute `crate` to specify the path of the `ref_cast` crate instance to use when referring to ref_cast APIs from generated code

**Please note:**
I didn't update the `trivial` attribute to `#[ref_cast(trivial)]` to keep the retro-compatibility