### PR TITLE
Use associated functions with visibility specifiers

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -43,10 +43,10 @@ fn expand(input: DeriveInput) -> Result<TokenStream2> {
     };
 
     Ok(quote! {
-        impl #impl_generics ::ref_cast::RefCast<#from> for #name #ty_generics #where_clause {
+        impl #impl_generics #name #ty_generics #where_clause {
 
             #[inline]
-            fn ref_cast(_from: &#from) -> &Self {
+            pub fn ref_cast(_from: &#from) -> &Self {
                 #assert_trivial_fields
                 #[cfg(debug_assertions)]
                 {
@@ -66,7 +66,7 @@ fn expand(input: DeriveInput) -> Result<TokenStream2> {
             }
 
             #[inline]
-            fn ref_cast_mut(_from: &mut #from) -> &mut Self {
+            pub fn ref_cast_mut(_from: &mut #from) -> &mut Self {
                 #[cfg(debug_assertions)]
                 {
                     #[allow(unused_imports)]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -249,6 +249,7 @@ fn compute_visibility(fields: &Fields) -> Result<Visibility> {
                 (Visibility::Crate(_), Visibility::Restricted(_)) => Some(field.vis.clone()),
                 (Visibility::Public(_), Visibility::Inherited) => Some(field.vis.clone()),
                 (Visibility::Crate(_), Visibility::Inherited) => Some(field.vis.clone()),
+                (Visibility::Restricted(_), Visibility::Inherited) => Some(field.vis.clone()),
                 (vis, _) => Some(vis),
             },
             None => Some(field.vis.clone()),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -43,45 +43,44 @@ fn expand(input: DeriveInput) -> Result<TokenStream2> {
     };
 
     Ok(quote! {
-        impl #impl_generics ::ref_cast::RefCast for #name #ty_generics #where_clause {
-            type From = #from;
+        impl #impl_generics ::ref_cast::RefCast<#from> for #name #ty_generics #where_clause {
 
             #[inline]
-            fn ref_cast(_from: &Self::From) -> &Self {
+            fn ref_cast(_from: &#from) -> &Self {
                 #assert_trivial_fields
                 #[cfg(debug_assertions)]
                 {
                     #[allow(unused_imports)]
                     use ::ref_cast::__private::LayoutUnsized;
-                    ::ref_cast::__private::assert_layout::<Self, Self::From>(
+                    ::ref_cast::__private::assert_layout::<Self, #from>(
                         #name_str,
                         ::ref_cast::__private::Layout::<Self>::SIZE,
-                        ::ref_cast::__private::Layout::<Self::From>::SIZE,
+                        ::ref_cast::__private::Layout::<#from>::SIZE,
                         ::ref_cast::__private::Layout::<Self>::ALIGN,
-                        ::ref_cast::__private::Layout::<Self::From>::ALIGN,
+                        ::ref_cast::__private::Layout::<#from>::ALIGN,
                     );
                 }
                 unsafe {
-                    &*(_from as *const Self::From as *const Self)
+                    &*(_from as *const #from as *const Self)
                 }
             }
 
             #[inline]
-            fn ref_cast_mut(_from: &mut Self::From) -> &mut Self {
+            fn ref_cast_mut(_from: &mut #from) -> &mut Self {
                 #[cfg(debug_assertions)]
                 {
                     #[allow(unused_imports)]
                     use ::ref_cast::__private::LayoutUnsized;
-                    ::ref_cast::__private::assert_layout::<Self, Self::From>(
+                    ::ref_cast::__private::assert_layout::<Self, #from>(
                         #name_str,
                         ::ref_cast::__private::Layout::<Self>::SIZE,
-                        ::ref_cast::__private::Layout::<Self::From>::SIZE,
+                        ::ref_cast::__private::Layout::<#from>::SIZE,
                         ::ref_cast::__private::Layout::<Self>::ALIGN,
-                        ::ref_cast::__private::Layout::<Self::From>::ALIGN,
+                        ::ref_cast::__private::Layout::<#from>::ALIGN,
                     );
                 }
                 unsafe {
-                    &mut *(_from as *mut Self::From as *mut Self)
+                    &mut *(_from as *mut #from as *mut Self)
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,31 +148,6 @@ mod trivial;
 
 pub use ref_cast_impl::RefCast;
 
-/// Safely cast `&T` to `&U` where the struct `U` contains a single field of
-/// type `T`.
-///
-/// ```
-/// # use ref_cast::RefCast;
-/// #
-/// // `&String` can be cast to `&U`.
-/// #[derive(RefCast)]
-/// #[repr(transparent)]
-/// struct U(String);
-///
-/// // `&T` can be cast to `&V<T>`.
-/// #[derive(RefCast)]
-/// #[repr(transparent)]
-/// struct V<T> {
-///     t: T,
-/// }
-/// ```
-///
-/// See the crate-level documentation for usage examples!
-pub trait RefCast<From: ?Sized> {
-    fn ref_cast(from: &From) -> &Self;
-    fn ref_cast_mut(from: &mut From) -> &mut Self;
-}
-
 // Not public API.
 #[doc(hidden)]
 pub mod __private {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,10 +168,9 @@ pub use ref_cast_impl::RefCast;
 /// ```
 ///
 /// See the crate-level documentation for usage examples!
-pub trait RefCast {
-    type From: ?Sized;
-    fn ref_cast(from: &Self::From) -> &Self;
-    fn ref_cast_mut(from: &mut Self::From) -> &mut Self;
+pub trait RefCast<From: ?Sized> {
+    fn ref_cast(from: &From) -> &Self;
+    fn ref_cast_mut(from: &mut From) -> &mut Self;
 }
 
 // Not public API.

--- a/tests/test_private.rs
+++ b/tests/test_private.rs
@@ -4,9 +4,39 @@ struct PrivateType(usize);
 
 #[derive(RefCast)]
 #[repr(transparent)]
-pub struct Wrapper(PrivateType);
+pub struct WrapPrivateType(PrivateType);
 
 #[test]
-fn test_private() {
-    Wrapper::ref_cast(&PrivateType(3));
+fn test_private_type() {
+    WrapPrivateType::ref_cast(&PrivateType(3));
+}
+
+mod inner {
+    #[derive(super::RefCast, Debug)]
+    #[repr(transparent)]
+    pub struct EvenNumber(usize);
+
+    impl EvenNumber {
+        pub fn try_ref_cast(input: &usize) -> Option<&EvenNumber> {
+            if input % 2 == 0 {
+                Some(Self::ref_cast(input))
+            } else {
+                None
+            }
+        }
+    }
+
+    #[derive(super::RefCast)]
+    #[repr(transparent)]
+    pub struct PubCrateWrap(pub(crate) usize);
+}
+
+#[test]
+fn test_inner_type() {
+    // error[E0624]: associated function `ref_cast` is private
+    // inner::EvenNumber::ref_cast(&4);
+
+    inner::EvenNumber::try_ref_cast(&4).unwrap();
+    inner::EvenNumber::try_ref_cast(&5).ok_or(()).expect_err("not an even number");
+    inner::PubCrateWrap::ref_cast(&5);
 }

--- a/tests/test_private.rs
+++ b/tests/test_private.rs
@@ -1,0 +1,12 @@
+use ref_cast::RefCast;
+
+struct PrivateType(usize);
+
+#[derive(RefCast)]
+#[repr(transparent)]
+pub struct Wrapper(PrivateType);
+
+#[test]
+fn test_private() {
+    Wrapper::ref_cast(&PrivateType(3));
+}


### PR DESCRIPTION
Fixes #3
Fixes #9

According to https://github.com/dtolnay/ref-cast/pull/10#pullrequestreview-345560340, using associated functions instead of traits is considered to be an option, so I implemented it in this way.