### PR TITLE
Add support for casting custom slices

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,10 @@ fn main() {
     if minor < 38 {
         println!("cargo:rustc-cfg=no_intrinsic_type_name");
     }
+
+    if minor < 51 {
+        println!("cargo:rustc-cfg=no_const_generics");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -15,6 +15,26 @@ where
     }
 }
 
+#[cfg(not(no_const_generics))]
+macro_rules! hide_from_old_rustc {
+    ($($tt:tt)*) => {
+        $($tt)*
+    };
+}
+
+#[cfg(not(no_const_generics))]
+hide_from_old_rustc! {
+    unsafe impl<From, To, const N: usize> RefCastCustom<[From; N]> for [To; N]
+    where
+        To: RefCastCustom<From>,
+    {
+        type CurrentCrate = To::CurrentCrate;
+        fn __static_assert() {
+            To::__static_assert();
+        }
+    }
+}
+
 pub unsafe trait RefCastOkay<From>: Sealed<From> {
     type CurrentCrate;
     type Target: ?Sized;

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -5,6 +5,16 @@ pub unsafe trait RefCastCustom<From: ?Sized> {
     fn __static_assert() {}
 }
 
+unsafe impl<From, To> RefCastCustom<[From]> for [To]
+where
+    To: RefCastCustom<From>,
+{
+    type CurrentCrate = To::CurrentCrate;
+    fn __static_assert() {
+        To::__static_assert();
+    }
+}
+
 pub unsafe trait RefCastOkay<From>: Sealed<From> {
     type CurrentCrate;
     type Target: ?Sized;

--- a/tests/test_custom.rs
+++ b/tests/test_custom.rs
@@ -1,0 +1,19 @@
+use ref_cast::{ref_cast_custom, RefCastCustom};
+
+#[derive(RefCastCustom)]
+#[repr(transparent)]
+pub struct Example(u32);
+
+impl Example {
+    #[ref_cast_custom]
+    const fn new_slice(ints: &[u32]) -> &[Self];
+}
+
+#[test]
+fn test_slice() {
+    let example = Example::new_slice(&[3, 2, 1]);
+    assert_eq!(example.len(), 3);
+    assert_eq!(example[0].0, 3);
+    assert_eq!(example[1].0, 2);
+    assert_eq!(example[2].0, 1);
+}

--- a/tests/ui/no-custom.stderr
+++ b/tests/ui/no-custom.stderr
@@ -4,7 +4,9 @@ error[E0277]: the trait bound `Thing: RefCastCustom<String>` is not satisfied
 8 |     pub fn ref_cast(s: &String) -> &Self;
   |                                    ^^^^^ the trait `RefCastCustom<String>` is not implemented for `Thing`
   |
-  = help: the trait `RefCastCustom<[From]>` is implemented for `[To]`
+  = help: the following other types implement trait `RefCastCustom<From>`:
+            <[To; N] as RefCastCustom<[From; N]>>
+            <[To] as RefCastCustom<[From]>>
   = note: required for `&Thing` to implement `ref_cast::custom::RefCastOkay<&String>`
 note: required by a bound in `ref_cast_custom`
  --> src/custom.rs
@@ -24,5 +26,7 @@ error[E0277]: the trait bound `Thing: RefCastCustom<String>` is not satisfied
 8 |     pub fn ref_cast(s: &String) -> &Self;
   |                                         ^ the trait `RefCastCustom<String>` is not implemented for `Thing`
   |
-  = help: the trait `RefCastCustom<[From]>` is implemented for `[To]`
+  = help: the following other types implement trait `RefCastCustom<From>`:
+            <[To; N] as RefCastCustom<[From; N]>>
+            <[To] as RefCastCustom<[From]>>
   = note: required for `&Thing` to implement `ref_cast::custom::RefCastOkay<&String>`

--- a/tests/ui/no-custom.stderr
+++ b/tests/ui/no-custom.stderr
@@ -4,9 +4,7 @@ error[E0277]: the trait bound `Thing: RefCastCustom<String>` is not satisfied
 8 |     pub fn ref_cast(s: &String) -> &Self;
   |                                    ^^^^^ the trait `RefCastCustom<String>` is not implemented for `Thing`
   |
-  = help: the following other types implement trait `ref_cast::custom::RefCastOkay<From>`:
-            <&'a To as ref_cast::custom::RefCastOkay<&'a From>>
-            <&'a mut To as ref_cast::custom::RefCastOkay<&'a mut From>>
+  = help: the trait `RefCastCustom<[From]>` is implemented for `[To]`
   = note: required for `&Thing` to implement `ref_cast::custom::RefCastOkay<&String>`
 note: required by a bound in `ref_cast_custom`
  --> src/custom.rs
@@ -26,7 +24,5 @@ error[E0277]: the trait bound `Thing: RefCastCustom<String>` is not satisfied
 8 |     pub fn ref_cast(s: &String) -> &Self;
   |                                         ^ the trait `RefCastCustom<String>` is not implemented for `Thing`
   |
-  = help: the following other types implement trait `ref_cast::custom::RefCastOkay<From>`:
-            <&'a To as ref_cast::custom::RefCastOkay<&'a From>>
-            <&'a mut To as ref_cast::custom::RefCastOkay<&'a mut From>>
+  = help: the trait `RefCastCustom<[From]>` is implemented for `[To]`
   = note: required for `&Thing` to implement `ref_cast::custom::RefCastOkay<&String>`


### PR DESCRIPTION
```rust
#[derive(RefCastCustom)]
#[repr(transparent)]
pub struct Example(u32);

impl Example {
    #[ref_cast_custom]
    const fn new_slice(ints: &[u32]) -> &[Self];
}
```