### PR TITLE
Suppress transmute_ptr_to_ptr pedantic clippy lint in generated code

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -369,6 +369,7 @@ fn expand_function_body(function: Function) -> TokenStream2 {
             let _ = ::ref_cast::__private::CurrentCrate::<#from_type, #to_type> {};
 
             #allow_unused_unsafe // in case they are building with deny(unsafe_op_in_unsafe_fn)
+            #[allow(clippy::transmute_ptr_to_ptr)]
             #our_unsafe {
                 ::ref_cast::__private::transmute::<#from_type, #to_type>(#arg)
             }


### PR DESCRIPTION
```console
warning: transmute from a reference to a reference
  --> tests/test_custom.rs:11:39
   |
11 |         pub fn new(s: &str) -> &Custom;
   |                                       ^ help: try: `&*(s as *const str as *const forbid_unsafe::Custom)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ptr
   = note: `-W clippy::transmute-ptr-to-ptr` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::transmute_ptr_to_ptr)]`
```