### PR TITLE
Ignore intentional unconstructed struct in ui test helper crate

### DIFF
--- a/tests/helper/lib.rs
+++ b/tests/helper/lib.rs
@@ -1,5 +1,7 @@
+#![allow(dead_code)]
+
 use ref_cast::RefCastCustom;
 
 #[derive(RefCastCustom)]
 #[repr(transparent)]
-pub struct Struct(#[allow(dead_code)] str);
+pub struct Struct(str);


### PR DESCRIPTION
The point of this struct is testing what happens if `#[ref_cast_custom]` is not used from the same crate as the `derive(RefCastCustom)` struct.

https://github.com/dtolnay/ref-cast/blob/daead7dc8411d174f95a3a375e2a6895ccc54da6/tests/ui/cross-crate.rs#L1-L5

https://github.com/dtolnay/ref-cast/blob/daead7dc8411d174f95a3a375e2a6895ccc54da6/tests/ui/cross-crate.stderr#L1-L5

Since https://github.com/rust-lang/rust/pull/125572, it has started producing a new dead_code warning.

```console
warning: struct `Struct` is never constructed
 --> tests/helper/lib.rs:5:12
  |
5 | pub struct Struct(#[allow(dead_code)] str);
  |            ^^^^^^
  |
  = note: `#[warn(dead_code)]` on by default
```