### PR TITLE
Exclude compile tests from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/ref-cast"
 rust-version = "1.61"
+include = ["src/**/*.rs", "build.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "README.md", "tests/test_*.rs"]
 
 [dependencies]
 ref-cast-impl = { version = "=1.0.25", path = "derive" }


### PR DESCRIPTION
During a dependency review I noticed that ref-cast includes the output of it's compile tests in the published package. These files are not required for building ref-cast as dependency and make it a bit harder to review the code.

This commit introduces a `include` directive in the `Cargo.toml` file to explicitly include only those files required to build `ref-cast`. This excludes the compile test artifacts and also reduces the size of the published crate from 43 files, 48.4KiB (14.8KiB compressed) to 15 files, 34.6KiB (11.3KiB compressed) which results in a 2GB/Month traffic reduction for crates.io assuming the current 6 million downloads and the difference in the compressed package size. I'm personally more interested in the reduction in the number of included files.